### PR TITLE
chore: use tinyglobby to drop 21 dependencies

### DIFF
--- a/fixtures/9-outside/spec.js
+++ b/fixtures/9-outside/spec.js
@@ -1,3 +1,3 @@
 // require a built-in module plus something from node_modules
 const fs = require('fs')
-const globby = require('globby')
+const tinyglobby = require('tinyglobby')

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "debug": "^4.3.4",
         "deep-equal": "^2.2.3",
         "dependency-tree": "^11.0.0",
-        "globby": "^11.1.0",
-        "lazy-ass": "^2.0.3"
+        "lazy-ass": "^2.0.3",
+        "tinyglobby": "^0.1.2"
       },
       "bin": {
         "spec-change": "bin/spec-change.js"
@@ -9577,6 +9577,45 @@
         "node": ">=4"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.1.2.tgz",
+      "integrity": "sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==",
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.2.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.2.0.tgz",
+      "integrity": "sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -16829,6 +16868,28 @@
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==",
       "dev": true
+    },
+    "tinyglobby": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.1.2.tgz",
+      "integrity": "sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==",
+      "requires": {
+        "fdir": "^6.2.0",
+        "picomatch": "^4.0.2"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.2.0.tgz",
+          "integrity": "sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==",
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
+        }
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "debug": "^4.3.4",
     "deep-equal": "^2.2.3",
     "dependency-tree": "^11.0.0",
-    "globby": "^11.1.0",
-    "lazy-ass": "^2.0.3"
+    "lazy-ass": "^2.0.3",
+    "tinyglobby": "^0.1.2"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const dependencyTree = require('dependency-tree')
 const path = require('path')
 const { lazyAss: la } = require('lazy-ass')
 const debug = require('debug')('spec-change')
-const globby = require('globby')
+const tinyglobby = require('tinyglobby')
 const fs = require('fs')
 const deepEqual = require('deep-equal')
 
@@ -195,7 +195,8 @@ function getDependsInFolder(options) {
   }
 
   const started = +new Date()
-  const files = globby.sync(fileMask, {
+  const files = tinyglobby.globSync({
+    patterns: [fileMask],
     cwd: folder,
     absolute: true,
   })


### PR DESCRIPTION
https://npmgraph.js.org/?q=globby - 23 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies