### PR TITLE
chore: add .gitattributes enforcing LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
This ensures that line endings will always be LF, regardless of the OS or git settings.

See also https://github.com/bahmutov/start-server-and-test/pull/468